### PR TITLE
Feat/config gem with slack creds

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -2,7 +2,8 @@
 detectors:
   Attribute:
     enabled: true
-    exclude: []
+    exclude:
+    - 'Configuration'
   BooleanParameter:
     enabled: true
     exclude: []
@@ -46,8 +47,9 @@ detectors:
     enabled: true
     exclude: []
   MissingSafeMethod:
-    enabled: true
-    exclude: []
+    enabled: false
+    exclude:
+    - 'Configuration#clear!'
   ModuleInitialize:
     enabled: true
     exclude: []

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
----
-sudo: false
-language: ruby
-cache: bundler
-rvm:
-  - 2.4.1
-before_install: gem install bundler -v 2.0.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     slack-msgr (0.1.0)
+      faraday (~> 0.15.4)
 
 GEM
   remote: https://rubygems.org/
@@ -21,11 +22,14 @@ GEM
     diff-lcs (1.3)
     docile (1.3.1)
     equalizer (0.0.11)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
     ice_nine (0.11.2)
     jaro_winkler (1.5.2)
     json (2.2.0)
     kwalify (0.7.2)
     method_source (0.9.2)
+    multipart-post (2.1.1)
     parallel (1.17.0)
     parser (2.6.3.0)
       ast (~> 2.4.0)

--- a/lib/config/initializer.rb
+++ b/lib/config/initializer.rb
@@ -2,4 +2,4 @@
 
 require_relative './version'
 
-Dir[File.expand_path "lib/slack_msgr/**/*.rb"].each { |f| require f }
+Dir[File.expand_path 'lib/slack_msgr/**/*.rb'].each { |f| require f }

--- a/lib/config/initializer.rb
+++ b/lib/config/initializer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 require_relative './version'
-Dir[File.join(__dir__, 'slack_msgr', '*.rb')].each { |f| require f }
+
+Dir[File.expand_path "lib/slack_msgr/**/*.rb"].each { |f| require f }

--- a/lib/slack_msgr.rb
+++ b/lib/slack_msgr.rb
@@ -8,5 +8,9 @@ module SlackMsgr
     def configuration
       @configuration ||= Configuration.new
     end
+
+    def configure
+      yield(configuration)
+    end
   end
 end

--- a/lib/slack_msgr.rb
+++ b/lib/slack_msgr.rb
@@ -4,4 +4,9 @@ require_relative './config/initializer'
 
 # Main module housing all classes, modules and methods for SlackMsgr
 module SlackMsgr
+  class << self
+    def configuration
+      @configuration ||= Configuration.new
+    end
+  end
 end

--- a/lib/slack_msgr/configuration.rb
+++ b/lib/slack_msgr/configuration.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 module SlackMsgr
   # Configuration class handling config variables set on launch
   class Configuration
-    attr_accessor :verification_token,
-                  :client_secret,
-                  :signing_secret
+    attr_reader :verification_token,
+                :client_secret,
+                :signing_secret
 
     def initialize(verification_token: nil, client_secret: nil, signing_secret: nil)
       @verification_token = verification_token

--- a/lib/slack_msgr/configuration.rb
+++ b/lib/slack_msgr/configuration.rb
@@ -3,14 +3,20 @@
 module SlackMsgr
   # Configuration class handling config variables set on launch
   class Configuration
-    attr_reader :verification_token,
-                :client_secret,
-                :signing_secret
+    attr_accessor :verification_token,
+                  :client_secret,
+                  :signing_secret
 
     def initialize(verification_token: nil, client_secret: nil, signing_secret: nil)
       @verification_token = verification_token
       @client_secret      = client_secret
       @signing_secret     = signing_secret
+    end
+
+    def clear!
+      @verification_token = nil
+      @client_secret      = nil
+      @signing_secret     = nil
     end
   end
 end

--- a/lib/slack_msgr/configuration.rb
+++ b/lib/slack_msgr/configuration.rb
@@ -1,0 +1,14 @@
+module SlackMsgr
+  # Configuration class handling config variables set on launch
+  class Configuration
+    attr_accessor :verification_token,
+                  :client_secret,
+                  :signing_secret
+
+    def initialize(verification_token: nil, client_secret: nil, signing_secret: nil)
+      @verification_token = verification_token
+      @client_secret      = client_secret
+      @signing_secret     = signing_secret
+    end
+  end
+end

--- a/slack-msgr.gemspec
+++ b/slack-msgr.gemspec
@@ -31,6 +31,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'faraday', '~>0.15.4'
+
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'

--- a/spec/integration/configure_slack_msgr_spec.rb
+++ b/spec/integration/configure_slack_msgr_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe 'configure SlackMsgr with tokens and secrets' do
+  it 'using SlackMsgr#configure' do
+    SlackMsgr.configure do |config|
+      config.verification_token = 'foo'
+      config.client_secret      = 'bar'
+      config.signing_secret     = 'baz'
+    end
+
+    expect(SlackMsgr.configuration.verification_token).to eq('foo')
+    expect(SlackMsgr.configuration.client_secret).to eq('bar')
+    expect(SlackMsgr.configuration.signing_secret).to eq('baz')
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ require 'pry'
 require 'simplecov'
 SimpleCov.start
 
-require './lib/config/initializer'
+require './lib/slack_msgr'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/unit/configuration_spec.rb
+++ b/spec/unit/configuration_spec.rb
@@ -1,23 +1,35 @@
 RSpec.describe SlackMsgr::Configuration do
+  let(:config) do
+    SlackMsgr::Configuration.new(
+      verification_token: 'foo',
+      client_secret:      'bar',
+      signing_secret:     'baz'
+    )
+  end
+
   describe '#initialize' do
     it 'can be initialized without parameters' do
-      config = SlackMsgr::Configuration.new
+      blank_config = SlackMsgr::Configuration.new
+
+      expect(blank_config.verification_token).to eq(nil)
+      expect(blank_config.client_secret).to eq(nil)
+      expect(blank_config.signing_secret).to eq(nil)
+    end
+
+    it 'can be initialized with parameters' do
+      expect(config.verification_token).to eq('foo')
+      expect(config.client_secret).to eq('bar')
+      expect(config.signing_secret).to eq('baz')
+    end
+  end
+
+  describe '#clear!' do
+    it 'permanently clears all configuration variables' do
+      config.clear!
 
       expect(config.verification_token).to eq(nil)
       expect(config.client_secret).to eq(nil)
       expect(config.signing_secret).to eq(nil)
-    end
-
-    it 'can be initialized with parameters' do
-      config = SlackMsgr::Configuration.new(
-        verification_token: 'foo',
-        client_secret:      'bar',
-        signing_secret:     'baz'
-      )
-
-      expect(config.verification_token).to eq('foo')
-      expect(config.client_secret).to eq('bar')
-      expect(config.signing_secret).to eq('baz')
     end
   end
 end

--- a/spec/unit/configuration_spec.rb
+++ b/spec/unit/configuration_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe SlackMsgr::Configuration do
+  describe '#initialize' do
+    it 'can be initialized without parameters' do
+      config = SlackMsgr::Configuration.new
+
+      expect(config.verification_token).to eq(nil)
+      expect(config.client_secret).to eq(nil)
+      expect(config.signing_secret).to eq(nil)
+    end
+
+    it 'can be initialized with parameters' do
+      config = SlackMsgr::Configuration.new(
+        verification_token: 'foo',
+        client_secret:      'bar',
+        signing_secret:     'baz'
+      )
+
+      expect(config.verification_token).to eq('foo')
+      expect(config.client_secret).to eq('bar')
+      expect(config.signing_secret).to eq('baz')
+    end
+  end
+end


### PR DESCRIPTION
Add functionality to configure Slack tokens and secrets.

```ruby
SlackMsgr.configure do |config|
  config.verification_token = 'foo'
  config.client_secret      = 'bar'
  config.signing_secret     = 'baz'
end
```